### PR TITLE
Fix PHP 7.1 error and use new s3 endpoint

### DIFF
--- a/S3SecureDownloadsPlugin.php
+++ b/S3SecureDownloadsPlugin.php
@@ -181,7 +181,7 @@ class S3SecureDownloadsPlugin extends BasePlugin
     protected function defineSettings()
     {
         return array(
-            'linkExpirationTime' => array(AttributeType::String, 'default' => ''),
+            'linkExpirationTime' => array(AttributeType::String, 'default' => '86400'),
             'forceFileDownload' => array(AttributeType::Bool, 'default' => 1),
             'requireLoggedInUser' => array(AttributeType::Bool, 'default' => 1)
         );

--- a/services/S3SecureDownloads_UrlService.php
+++ b/services/S3SecureDownloads_UrlService.php
@@ -48,8 +48,8 @@ class S3SecureDownloads_UrlService extends BaseApplicationComponent
 
 		$resource = str_replace( array( '%2F', '%2B' ), array( '/', '+' ), rawurlencode( $baseAssetPath ) );
 
-		$string_to_sign = "GET\n\n\n$expires\n/$bucketName/$resource";
-		$final_url = "https://s3.amazonaws.com/$bucketName/$resource?";
+		$string_to_sign = "GET\n\n\n{$expires}\n/{$bucketName}/{$resource}";
+		$final_url = "https://{$bucketName}.s3.amazonaws.com/{$resource}?";
 
 		$append_char = '?';
 		foreach ( $headers as $header => $value ) {

--- a/templates/S3SecureDownloads_Settings.twig
+++ b/templates/S3SecureDownloads_Settings.twig
@@ -16,7 +16,7 @@
 
 {{ forms.textField({
     label: 'Link Expiration Time',
-    instructions: 'Enter the expiration time (in seconds) for your signed URLs.',
+    instructions: 'Enter the expiration time (in seconds) for your signed URLs. Default is 24 hours.',
     id: 'linkExpirationTime',
     name: 'linkExpirationTime', 
     value: settings['linkExpirationTime']})


### PR DESCRIPTION
This PR fixes the "A non-numeric value encountered" error in PHP 7.1 when the user forgets to set an explicit expiration time. This by making the plugin setting 24 hrs as a default (this can be lowered if you think that's sensible).

It also changes the amazon s3 endpoint to the new scheme in order to solve the “permanent redirect” error that occurred when trying to use the link.