### PR TITLE
Adds support for Asset Source subfolders, and for missing URLs on entries 

### DIFF
--- a/services/S3SecureDownloads_UrlService.php
+++ b/services/S3SecureDownloads_UrlService.php
@@ -19,9 +19,9 @@ class S3SecureDownloads_UrlService extends BaseApplicationComponent
 		$sourceType = craft()->assetSources->getSourceTypeById( $entry->sourceId );
 		$assetSettings = $sourceType->getSettings();
 
-		$urlPrefix = $assetSettings->urlPrefix;
 		$assetUrl = $entry->filename;
 
+		$urlPrefix = $assetSettings->urlPrefix . $assetSettings->subfolder;
 
 		// Remove the mtime query string just in case Craft adds it.
 		$baseAssetPath = str_replace( $urlPrefix, "", UrlHelper::stripQueryString($assetUrl) );

--- a/services/S3SecureDownloads_UrlService.php
+++ b/services/S3SecureDownloads_UrlService.php
@@ -16,12 +16,12 @@ class S3SecureDownloads_UrlService extends BaseApplicationComponent
 
 		$entry = craft()->elements->getElementById( $entry_id );
 
-		$assetUrl = $entry->url;
-
 		$sourceType = craft()->assetSources->getSourceTypeById( $entry->sourceId );
 		$assetSettings = $sourceType->getSettings();
 
 		$urlPrefix = $assetSettings->urlPrefix;
+		$assetUrl = $entry->filename;
+
 
 		// Remove the mtime query string just in case Craft adds it.
 		$baseAssetPath = str_replace( $urlPrefix, "", UrlHelper::stripQueryString($assetUrl) );

--- a/services/S3SecureDownloads_UrlService.php
+++ b/services/S3SecureDownloads_UrlService.php
@@ -15,20 +15,17 @@ class S3SecureDownloads_UrlService extends BaseApplicationComponent
 	public function getSignedUrl( $entry_id ) {
 
 		$entry = craft()->elements->getElementById( $entry_id );
+		$fileName = $entry->filename;
 
 		$sourceType = craft()->assetSources->getSourceTypeById( $entry->sourceId );
 		$assetSettings = $sourceType->getSettings();
-
-		$assetUrl = $entry->filename;
-
-		$urlPrefix = $assetSettings->urlPrefix . $assetSettings->subfolder;
-
-		// Remove the mtime query string just in case Craft adds it.
-		$baseAssetPath = str_replace( $urlPrefix, "", UrlHelper::stripQueryString($assetUrl) );
-
-
-		$fileName = $entry->filename;
 		$bucketName = $assetSettings->bucket;
+
+		// Add slash to end of path, since subfolder may not have it
+		// https://stackoverflow.com/a/9339669/864799
+		$urlPrefix = rtrim( $assetSettings->subfolder, "/" ) . "/";
+
+		$baseAssetPath = $urlPrefix . $fileName;
 		$keyId = $assetSettings->keyId;
 		$secretKey = $assetSettings->secret;
 		$linkExpirationTime = $this->getSetting( "linkExpirationTime" );


### PR DESCRIPTION
I think because I have an Asset Source with the “Assets in this source have public URLs” setting turned off, those entries don’t have an `$entry->url`. Instead, I’m using the filename, since the rest of the URL is being constructed anyway. From my testing, the result was the same, but there might be more to it than I’m realising there.

I’m also using the Subfolder setting to specify a location within a bucket, which I don’t think was supported by this plugin before.