### PR TITLE
Adds “asset” as the getElementById() type

### DIFF
--- a/services/S3SecureDownloads_UrlService.php
+++ b/services/S3SecureDownloads_UrlService.php
@@ -14,7 +14,7 @@ class S3SecureDownloads_UrlService extends BaseApplicationComponent
 
 	public function getSignedUrl( $entry_id ) {
 
-		$entry = craft()->elements->getElementById( $entry_id );
+		$entry = craft()->elements->getElementById( $entry_id, ElementType::Asset );
 		$fileName = $entry->filename;
 
 		$sourceType = craft()->assetSources->getSourceTypeById( $entry->sourceId );

--- a/services/S3SecureDownloads_UrlService.php
+++ b/services/S3SecureDownloads_UrlService.php
@@ -15,20 +15,17 @@ class S3SecureDownloads_UrlService extends BaseApplicationComponent
 	public function getSignedUrl( $entry_id ) {
 
 		$entry = craft()->elements->getElementById( $entry_id );
-
-		$assetUrl = $entry->url;
+		$fileName = $entry->filename;
 
 		$sourceType = craft()->assetSources->getSourceTypeById( $entry->sourceId );
 		$assetSettings = $sourceType->getSettings();
-
-		$urlPrefix = $assetSettings->urlPrefix;
-
-		// Remove the mtime query string just in case Craft adds it.
-		$baseAssetPath = str_replace( $urlPrefix, "", UrlHelper::stripQueryString($assetUrl) );
-
-
-		$fileName = $entry->filename;
 		$bucketName = $assetSettings->bucket;
+
+		// Add slash to end of path, since subfolder may not have it
+		// https://stackoverflow.com/a/9339669/864799
+		$urlPrefix = rtrim( $assetSettings->subfolder, "/" ) . "/";
+
+		$baseAssetPath = $urlPrefix . $fileName;
 		$keyId = $assetSettings->keyId;
 		$secretKey = $assetSettings->secret;
 		$linkExpirationTime = $this->getSetting( "linkExpirationTime" );


### PR DESCRIPTION
I’m not especially familiar with this, but when I was reviewing [the docs for `getElementById()`](https://craftcms.com/classreference/services/ElementsService#getElementById-detail), I saw it suggested passing in an `$elementType` for one less DB query. So this PR does that!